### PR TITLE
Default date for page and remind commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.iml
 users.json
 bot_settings.py
+*.pyc
+__pycache__

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ Install requirements with `pip install -r requirements.txt`
 
 Commands:
 * `python run.py users` to generate userlist, this must be done only if something changed since last run
-* `python run.py page <DATE>` to create wiki page and send first reminder to Slack. `<DATE>` will be used in page title and must be unique
-* `python run.py remind <DATE>` to send second Slack notification with non-filled cells mention
+* `python run.py page [<DATE>]` to create wiki page and send first reminder to Slack. `<DATE>` will be used in page title and must be unique. If date is not provided, bot will try to use `bot_settings.defaults['date']`
+* `python run.py remind [<DATE>]` to send second Slack notification with non-filled cells mention

--- a/bot_settings.py.ex
+++ b/bot_settings.py.ex
@@ -1,4 +1,9 @@
 import logging
+from lib.utils import get_nearest_day_of_week
+
+defaults = {
+    'date': get_nearest_day_of_week(4),  # nearest friday
+}
 
 confluence_settings = {
     'jira_base_url': 'jira.hh.ru',

--- a/lib/handlers/page.py
+++ b/lib/handlers/page.py
@@ -5,9 +5,12 @@ from lib.api_clients.confluence import ConfluenceClient
 from lib.api_clients.slack import SlackClient
 from lib.templates import SLACK_PAGE_MESSAGE_TEMPLATE, TITLE_TEMPLATE, PAGE_TEMPLATE, USER_ROW_TEMPLATE, \
     TEAM_ROW_TEMPLATE
+from lib.utils import get_usable_date
 
 
-def generate_page(date):
+def generate_page(params_date=None):
+    date = get_usable_date(params_date, bot_settings.defaults)
+
     confluence = ConfluenceClient(
         bot_settings.confluence_settings['login'],
         bot_settings.confluence_settings['password']

--- a/lib/handlers/remind.py
+++ b/lib/handlers/remind.py
@@ -7,9 +7,12 @@ from lib.api_clients.confluence import ConfluenceClient
 from lib.api_clients.slack import SlackClient
 from lib.templates import TITLE_TEMPLATE, SLACK_REMIND_MESSAGE_TEMPLATE, SLACK_REMIND_ALL_CHECKED_TEMPLATE, \
     SLACK_REMIND_HAS_UNCHECKED_TEMPLATE
+from lib.utils import get_usable_date
 
 
-def remind_users(date):
+def remind_users(params_date=None):
+    date = get_usable_date(params_date, bot_settings.defaults)
+
     confluence = ConfluenceClient(
         bot_settings.confluence_settings['login'],
         bot_settings.confluence_settings['password']

--- a/lib/runner.py
+++ b/lib/runner.py
@@ -1,8 +1,11 @@
 import sys
+import urllib3
 
 from lib.handlers.users import generate_users
 from lib.handlers.page import generate_page
 from lib.handlers.remind import remind_users
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 AVAILABLE_COMMANDS = {
     'users': {

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,0 +1,19 @@
+import datetime
+
+
+def get_nearest_day_of_week(index):
+    date = datetime.date.today()
+    while date.weekday() != index:
+        date += datetime.timedelta(1)
+
+    return date.strftime('%Y-%m-%d')
+
+
+def get_usable_date(params_date=None, defaults=None):
+    if params_date is not None:
+        return params_date
+
+    if defaults is not None and 'date' in defaults and defaults['date'] is not None:
+        return defaults['date']
+
+    raise AttributeError('You must provide date either as parameter or bot settings default value')


### PR DESCRIPTION
page and remind commands now usable without any parameters if proper date provided in bot settings